### PR TITLE
feat: showboat sidenote prototype (issue #26)

### DIFF
--- a/astro-site/src/components/ShowboatInit.astro
+++ b/astro-site/src/components/ShowboatInit.astro
@@ -1,0 +1,61 @@
+---
+---
+<!--
+  Showboat sidenote prototype
+  Inspired by https://github.com/simonw/showboat
+
+  Converts remark-gfm footnotes ([^1] syntax) into margin sidenotes on wide screens.
+  On narrow screens, standard footnotes at the bottom remain visible.
+
+  Footnote HTML output from remark-gfm:
+    <sup><a href="#user-content-fn-1" data-footnote-ref ...>1</a></sup>
+    <section data-footnotes>
+      <ol><li id="user-content-fn-1"><p>Content <a data-footnote-backref ...>↩</a></p></li></ol>
+    </section>
+-->
+<script>
+  function initShowboat() {
+    const footnoteRefs = document.querySelectorAll<HTMLAnchorElement>('[data-footnote-ref]');
+    const footnotesSection = document.querySelector<HTMLElement>('[data-footnotes]');
+
+    if (!footnoteRefs.length || !footnotesSection) return;
+
+    footnoteRefs.forEach((refLink, index) => {
+      const footnoteId = refLink.getAttribute('href')?.slice(1); // strip leading #
+      if (!footnoteId) return;
+
+      const footnoteItem = document.getElementById(footnoteId);
+      if (!footnoteItem) return;
+
+      // Clone footnote content and remove the back-reference arrow
+      const clone = footnoteItem.cloneNode(true) as HTMLElement;
+      clone.querySelectorAll('[data-footnote-backref]').forEach(el => el.remove());
+
+      const paragraphs = Array.from(clone.querySelectorAll('p'));
+      const contentHTML = paragraphs.map(p => p.innerHTML.trim()).join(' ');
+
+      const sidenote = document.createElement('aside');
+      sidenote.className = 'sidenote';
+      sidenote.innerHTML = `<sup class="sidenote-number">${index + 1}</sup> ${contentHTML}`;
+
+      // Insert before the paragraph so the float appears alongside its reference
+      const parentParagraph =
+        refLink.closest('p') ?? refLink.closest('li') ?? refLink.parentElement;
+      if (parentParagraph) {
+        parentParagraph.insertAdjacentElement('beforebegin', sidenote);
+      }
+    });
+
+    // On wide screens, hide the footnotes section at the bottom
+    if (window.matchMedia('(min-width: 1280px)').matches) {
+      footnotesSection.setAttribute('aria-hidden', 'true');
+      footnotesSection.style.display = 'none';
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initShowboat);
+  } else {
+    initShowboat();
+  }
+</script>

--- a/astro-site/src/content/blog/sidenote-annotations-prototype.md
+++ b/astro-site/src/content/blog/sidenote-annotations-prototype.md
@@ -1,0 +1,38 @@
+---
+title: "Sidenote Annotations: A Prototype"
+description: "A prototype of thinkingmachines-style margin annotations using footnote syntax."
+pubDate: 2026-05-14
+draft: true
+tags: [design, prototype]
+aiUsage: "co-authored"
+---
+
+This post is a prototype for [issue #26](https://github.com/PhilipMathieu/portfolio-blog/issues/26) — adopting margin annotations in the style of [thinkingmachines.ai/blog](https://thinkingmachines.ai/blog/). On a wide screen you should see the footnotes float into the right margin as sidenotes.[^1]
+
+## How it works
+
+Standard Markdown footnotes[^2] are authored inline using the `[^label]` syntax. At build time, Astro's remark-gfm plugin converts them to HTML superscript references with a footnotes section at the bottom of the page. The `ShowboatInit.astro` component[^3] then runs client-side to lift those footnote items out of the bottom section and place them as `<aside class="sidenote">` elements in the margin.
+
+On screens narrower than 1280 px the sidenotes are hidden via CSS and the standard footnotes section at the bottom remains visible and accessible.[^4]
+
+## Positioning approach
+
+The sidenotes use `float: right` with a negative `margin-right` to push the element past the prose's right edge into the gutter.[^5] This avoids the need for JavaScript-calculated `top` values and lets the browser handle vertical stacking through `clear: right`.
+
+The prose container is `max-w-[720px]` inside a `max-w-[1020px]` outer wrapper, leaving ~150 px of gutter on each side within the outer wrapper. At a 1280 px viewport there is ~130 px of additional margin outside the outer wrapper, so a 220 px sidenote fits with a small buffer.
+
+## Adapting to the real showboat library
+
+This prototype mirrors the pattern that [simonw/showboat](https://github.com/simonw/showboat) uses. Swapping in the actual library would mean:
+
+1. Install showboat (e.g., `npm install simonw/showboat`)
+2. Replace the inline script in `ShowboatInit.astro` with an `import` of showboat's entry point
+3. Call showboat's initializer instead of the custom `initShowboat()` function
+
+The CSS (sidenote width, colors, border) can stay in `global.css` regardless of which JS drives the positioning.
+
+[^1]: Resize the browser window below 1280 px to see them collapse back to footnotes at the bottom of the page.
+[^2]: GFM (GitHub Flavored Markdown) footnote syntax: `[^label]` in the text, `[^label]: content` as the definition anywhere in the file. The label can be a number or a word.
+[^3]: `ShowboatInit.astro` lives in `src/components/` alongside `MermaidInit.astro` and `CopyButtonInit.astro`. It is included unconditionally in `BlogPost.astro`; posts without footnotes are unaffected.
+[^4]: Footnote accessibility: screen readers see the original `<section data-footnotes>` because we only set `display: none` on wide screens, not on narrow ones. The back-reference links (↩) remain in the footnotes section.
+[^5]: The exact CSS: `float: right; clear: right; margin-right: -250px; width: 220px`. At 1280 px viewport, the sidenote's right edge lands ~30 px from the viewport edge — enough for a comfortable visual buffer.

--- a/astro-site/src/layouts/BlogPost.astro
+++ b/astro-site/src/layouts/BlogPost.astro
@@ -7,6 +7,7 @@ import FormattedDate from '../components/FormattedDate.astro';
 import Header from '../components/Header.astro';
 import MermaidInit from '../components/MermaidInit.astro';
 import CopyButtonInit from '../components/CopyButtonInit.astro';
+import ShowboatInit from '../components/ShowboatInit.astro';
 import ShareButton from '../components/ShareButton.astro';
 import AIUsageBadge from '../components/AIUsageBadge.astro';
 import { generateGradient } from '../utils/gradient';
@@ -69,5 +70,6 @@ const isAboutPage = Astro.url.pathname === '/about/' || Astro.url.pathname === '
 		<Footer />
 		<MermaidInit />
 		<CopyButtonInit />
+		<ShowboatInit />
 	</body>
 </html>

--- a/astro-site/src/styles/global.css
+++ b/astro-site/src/styles/global.css
@@ -264,4 +264,55 @@
 	.copy-button.copied {
 		@apply bg-primary-500 text-white;
 	}
+
+	/* ── Showboat sidenotes ─────────────────────────────────────────────────── */
+	/* On wide screens, footnotes float into the right margin as sidenotes.      */
+	/* On narrow screens they stay hidden (the footnotes section at the bottom   */
+	/* remains visible instead).                                                 */
+
+	@media (min-width: 1280px) {
+		.sidenote {
+			float: right;
+			clear: right;
+			/* Push the sidenote past the prose's right edge.
+			   prose=720px inside max-w-[1020px]; at 1280px viewport
+			   the available space to the right is enough to fit 220px. */
+			margin-right: -250px;
+			margin-top: 0.15rem;
+			margin-bottom: 1rem;
+			margin-left: 0;
+			width: 220px;
+			font-size: 0.78em;
+			line-height: 1.5;
+			color: var(--gray-500);
+			padding-left: 0.6rem;
+			border-left: 2px solid var(--gray-300);
+		}
+
+		.sidenote .sidenote-number {
+			color: var(--primary-500);
+			font-weight: 600;
+			font-size: 0.75em;
+			vertical-align: super;
+			margin-right: 0.2em;
+		}
+
+		.sidenote a {
+			color: var(--link-500);
+		}
+
+		/* Style the inline reference number */
+		sup:has([data-footnote-ref]),
+		sup [data-footnote-ref] {
+			color: var(--primary-500);
+			font-weight: 600;
+		}
+	}
+
+	/* Sidenotes are decorative-only; keep footnotes accessible on small screens */
+	@media (max-width: 1279px) {
+		.sidenote {
+			display: none;
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Prototype of thinkingmachines-style margin annotations using a footnote-to-sidenote converter inspired by [simonw/showboat](https://github.com/simonw/showboat).

- `ShowboatInit.astro` — client-side JS that lifts remark-gfm footnotes into floated `<aside class="sidenote">` elements next to their reference
- Sidenote CSS in `global.css` — floats into the gutter at ≥1280px, hides and falls back to the standard footnotes section below 1280px
- Draft demo post `sidenote-annotations-prototype.md` with five footnotes to exercise the pattern

**Note:** the CI environment that produced this branch couldn't reach the network, so the actual `simonw/showboat` library isn't imported — the prototype reimplements the same footnote-to-sidenote lift pattern. Swapping in the real library would mean importing it in `ShowboatInit.astro` and replacing `initShowboat()` with the library's initializer; the CSS and layout stay the same.

Closes #26

## Test plan

- [ ] `npm run dev` and open the demo post — sidenotes appear in the right margin on wide screens
- [ ] Resize below 1280px — sidenotes hide, footnotes section at the bottom remains accessible
- [ ] Confirm existing posts without footnotes are unaffected
- [ ] Decide whether to swap in the real `simonw/showboat` library before merge

Generated with [Claude Code](https://claude.ai/code)