### PR TITLE
Add Umami Cloud analytics with UTM referral tracking

### DIFF
--- a/astro-site/CLOUDFLARE-PAGES.md
+++ b/astro-site/CLOUDFLARE-PAGES.md
@@ -28,6 +28,15 @@ astro-site
 
 Add any required environment variables in the Cloudflare Pages dashboard under **Settings** > **Environment variables**.
 
+| Variable | Purpose |
+| --- | --- |
+| `PUBLIC_UMAMI_WEBSITE_ID` | Website ID from [Umami Cloud](https://cloud.umami.is) (Settings > Websites > Edit). Enables the analytics script; when unset, no analytics are loaded. |
+
+Analytics notes:
+
+- The Umami script only renders in production builds, and `data-domains` limits tracking to the production hostname, so `.pages.dev` preview deployments and local dev are never counted.
+- Umami records `utm_*` query parameters automatically — see the **UTM** report in the Umami dashboard for referral campaign tracking. The site's share button tags copied/shared links with `utm_source=share_button` so those visits are attributable.
+
 ## After Setup
 
 Once configured, Cloudflare Pages will:

--- a/astro-site/src/components/BaseHead.astro
+++ b/astro-site/src/components/BaseHead.astro
@@ -4,6 +4,7 @@
 import '../styles/global.css';
 import type { ImageMetadata } from 'astro';
 import { SITE_TITLE } from '../consts';
+import Umami from './Umami.astro';
 
 interface Props {
 	title: string;
@@ -37,6 +38,9 @@ const { title, description, image } = Astro.props;
 />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.25/dist/katex.min.css" integrity="sha384-Zi52hHXOLjmD8g7sDwZ6GS8nKM8lKQKfU0e8nfY5h5nHy0nL/6nD8nP2VNVfwfnk" crossorigin="anonymous" />
 <meta name="generator" content={Astro.generator} />
+
+<!-- Analytics -->
+<Umami />
 
 <!-- Canonical URL -->
 <link rel="canonical" href={canonicalURL} />

--- a/astro-site/src/components/ShareButton.astro
+++ b/astro-site/src/components/ShareButton.astro
@@ -21,9 +21,24 @@ const shareUrl = url || Astro.url.href;
 </button>
 
 <script>
+	// Tag shared links with UTM parameters so visits from them show up as
+	// share-button referrals in Umami. Leaves any existing utm_* params intact.
+	function withUtmParams(url: string, medium: string): string {
+		try {
+			const tagged = new URL(url, window.location.href);
+			if (!tagged.searchParams.has('utm_source')) {
+				tagged.searchParams.set('utm_source', 'share_button');
+				tagged.searchParams.set('utm_medium', medium);
+			}
+			return tagged.href;
+		} catch {
+			return url;
+		}
+	}
+
 	document.addEventListener('DOMContentLoaded', () => {
 		const shareButtons = document.querySelectorAll('.share-button');
-		
+
 		shareButtons.forEach((shareButton) => {
 			shareButton.addEventListener('click', async () => {
 				const shareUrl = shareButton.dataset.url || window.location.href;
@@ -34,7 +49,7 @@ const shareUrl = url || Astro.url.href;
 					try {
 						await navigator.share({
 							title: shareTitle,
-							url: shareUrl,
+							url: withUtmParams(shareUrl, 'web_share'),
 						});
 						return;
 					} catch (err) {
@@ -46,8 +61,9 @@ const shareUrl = url || Astro.url.href;
 				}
 
 				// Fallback to clipboard
+				const clipboardUrl = withUtmParams(shareUrl, 'clipboard');
 				try {
-					await navigator.clipboard.writeText(shareUrl);
+					await navigator.clipboard.writeText(clipboardUrl);
 					const shareText = shareButton.querySelector('.share-text');
 					const originalText = shareText?.textContent || 'Share';
 					if (shareText) {
@@ -60,7 +76,7 @@ const shareUrl = url || Astro.url.href;
 					console.error('Failed to copy to clipboard:', err);
 					// Fallback for older browsers
 					const textArea = document.createElement('textarea');
-					textArea.value = shareUrl;
+					textArea.value = clipboardUrl;
 					textArea.style.position = 'fixed';
 					textArea.style.opacity = '0';
 					document.body.appendChild(textArea);

--- a/astro-site/src/components/Umami.astro
+++ b/astro-site/src/components/Umami.astro
@@ -1,0 +1,22 @@
+---
+// Umami Cloud analytics. Renders nothing unless PUBLIC_UMAMI_WEBSITE_ID is set
+// (configure it in the Cloudflare Pages dashboard) and the build is production,
+// so dev servers and unconfigured builds send no data.
+// Umami automatically records utm_* query parameters on incoming pageviews,
+// which powers the UTM/referral reports in the dashboard.
+const websiteId = import.meta.env.PUBLIC_UMAMI_WEBSITE_ID;
+const domain = Astro.site ? new URL(Astro.site).hostname : undefined;
+const enabled = import.meta.env.PROD && websiteId;
+---
+
+{
+	enabled && (
+		<script
+			is:inline
+			defer
+			src="https://cloud.umami.is/script.js"
+			data-website-id={websiteId}
+			data-domains={domain}
+		/>
+	)
+}

--- a/astro-site/src/env.d.ts
+++ b/astro-site/src/env.d.ts
@@ -1,4 +1,11 @@
 /// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />
 
+interface ImportMetaEnv {
+	/** Umami Cloud website ID; analytics are disabled when unset. */
+	readonly PUBLIC_UMAMI_WEBSITE_ID?: string;
+}
 
+interface ImportMeta {
+	readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
- New Umami.astro component loads the Umami Cloud script on all pages
  via BaseHead, gated on the PUBLIC_UMAMI_WEBSITE_ID env var and
  production builds; data-domains restricts tracking to the production
  hostname so preview deployments and local dev are never counted
- Share button now tags shared/copied links with utm_source=share_button
  and a utm_medium of web_share or clipboard so those referrals are
  attributable in Umami's UTM reports
- Type the new env var in env.d.ts and document setup in
  CLOUDFLARE-PAGES.md

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011DyMQBE7sAvYGuQ2Zq3WM1